### PR TITLE
Fix styling issue with feedback activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         <activity
                 android:name=".ui.FeedbackActivity"
                 android:label="@string/feedback_title"
-                android:theme="@style/AppTheme.CustomTheme" />
+                android:theme="@style/AppTheme.CustomDialogTheme" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ui/fitit/ui/FeedbackActivity.java
+++ b/app/src/main/java/com/ui/fitit/ui/FeedbackActivity.java
@@ -2,7 +2,6 @@ package com.ui.fitit.ui;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -55,13 +54,6 @@ public class FeedbackActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_feedback);
-
-        // Set the form to be 50% of the screen
-        DisplayMetrics dm = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(dm);
-        int width = dm.widthPixels;
-        int height = dm.heightPixels;
-        getWindow().setLayout((int) (width * 0.9), (int) (height * 0.5));
 
         initView();
         setupPersistentStorage();

--- a/app/src/main/res/layout/activity_feedback.xml
+++ b/app/src/main/res/layout/activity_feedback.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/relativeLayout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-
-    tools:context=".ui.FeedbackActivity">
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/relativeLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:context=".ui.FeedbackActivity">
 
     <!-- The primary full-screen view. This can be replaced with whatever view
          is needed to present your content, e.g. VideoView, SurfaceView,
@@ -17,186 +16,186 @@
 
 
     <LinearLayout
-        android:id="@+id/linearLayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@drawable/feedback_background"
-        android:orientation="vertical"
-        android:padding="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/q1"
+            android:id="@+id/linearLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingVertical="4dp"
-            android:text="@string/feedback_q1"
-            android:textColor="@color/black" />
+            android:background="@drawable/feedback_background"
+            android:orientation="vertical"
+            android:padding="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+                android:id="@+id/q1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="4dp"
+                android:text="@string/feedback_q1"
+                android:textColor="@color/black" />
 
         <RadioGroup
-            android:id="@+id/motivationButtonsGroup"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_gravity="center"
-            android:layout_weight="1"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/m1_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:id="@+id/motivationButtonsGroup"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
                 android:layout_gravity="center"
                 android:layout_weight="1"
-                android:text="@string/m1_text"
-                android:textColor="@color/black" />
-
-            <RadioButton
-                android:id="@+id/m1_button"
-                style="@style/RadioButtonWithTextOnTop"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/m1" />
-
-            <RadioButton
-                android:id="@+id/m2_button"
-                style="@style/RadioButtonWithTextOnTop"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/m2" />
-
-            <RadioButton
-                android:id="@+id/m3_button"
-                style="@style/RadioButtonWithTextOnTop"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/m3" />
-
-            <RadioButton
-                android:id="@+id/m4_button"
-                style="@style/RadioButtonWithTextOnTop"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/m4" />
-
-            <RadioButton
-                android:id="@+id/m5_button"
-                style="@style/RadioButtonWithTextOnTop"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/m5" />
+                android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/m5_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_weight="1"
-                android:text="@string/m5_text"
-                android:textColor="@color/black" />
+                    android:id="@+id/m1_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="1"
+                    android:text="@string/m1_text"
+                    android:textColor="@color/black" />
+
+            <RadioButton
+                    android:id="@+id/m1_button"
+                    style="@style/RadioButtonWithTextOnTop"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/m1" />
+
+            <RadioButton
+                    android:id="@+id/m2_button"
+                    style="@style/RadioButtonWithTextOnTop"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/m2" />
+
+            <RadioButton
+                    android:id="@+id/m3_button"
+                    style="@style/RadioButtonWithTextOnTop"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/m3" />
+
+            <RadioButton
+                    android:id="@+id/m4_button"
+                    style="@style/RadioButtonWithTextOnTop"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/m4" />
+
+            <RadioButton
+                    android:id="@+id/m5_button"
+                    style="@style/RadioButtonWithTextOnTop"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/m5" />
+
+            <TextView
+                    android:id="@+id/m5_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="1"
+                    android:text="@string/m5_text"
+                    android:textColor="@color/black" />
 
         </RadioGroup>
 
         <CheckBox
-            android:id="@+id/workedTodayCheckBox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingVertical="10dp"
-            android:text="@string/feedback_q4" />
-
-        <LinearLayout
-            android:id="@+id/progressQuestion"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:visibility="gone">
-
-            <TextView
-                android:id="@+id/q2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingVertical="10dp"
-                android:text="@string/feedback_q2"
-                android:textColor="@color/black" />
-
-            <TextView
-                android:id="@+id/progress"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center" />
-
-            <SeekBar
-                android:id="@+id/successSeekbar"
-                style="@android:style/Widget.Material.SeekBar.Discrete"
+                android:id="@+id/workedTodayCheckBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:max="100"
-                android:progress="0"
-                android:thumbTint="@color/colorAccent" />
+                android:paddingVertical="10dp"
+                android:text="@string/feedback_q4" />
+
+        <LinearLayout
+                android:id="@+id/progressQuestion"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+            <TextView
+                    android:id="@+id/q2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingVertical="10dp"
+                    android:text="@string/feedback_q2"
+                    android:textColor="@color/black" />
+
+            <TextView
+                    android:id="@+id/progress"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center" />
+
+            <SeekBar
+                    android:id="@+id/successSeekbar"
+                    style="@android:style/Widget.Material.SeekBar.Discrete"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:max="100"
+                    android:progress="0"
+                    android:thumbTint="@color/colorAccent" />
         </LinearLayout>
 
         <TextView
-            android:id="@+id/q3"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingVertical="10dp"
-            android:text="@string/feedback_q3"
-            android:textColor="@color/black" />
+                android:id="@+id/q3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="10dp"
+                android:text="@string/feedback_q3"
+                android:textColor="@color/black" />
 
         <RadioGroup
-            android:id="@+id/feelingGroup"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:orientation="horizontal">
+                android:id="@+id/feelingGroup"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:orientation="horizontal">
 
             <RadioButton
-                android:id="@+id/notWellButton"
-                style="?android:borderlessButtonStyle"
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                android:layout_marginHorizontal="10dp"
-                android:background="@drawable/ic_sad"
-                android:button="@null"
-                android:paddingHorizontal="10dp" />
+                    android:id="@+id/notWellButton"
+                    style="?android:borderlessButtonStyle"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_marginHorizontal="10dp"
+                    android:background="@drawable/ic_sad"
+                    android:button="@null"
+                    android:paddingHorizontal="10dp" />
 
             <RadioButton
-                android:id="@+id/neutralButton"
-                style="?android:borderlessButtonStyle"
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                android:layout_marginHorizontal="10dp"
-                android:layout_weight="1"
-                android:background="@drawable/ic_neutral"
-                android:button="@null"
-                android:paddingHorizontal="10dp" />
+                    android:id="@+id/neutralButton"
+                    style="?android:borderlessButtonStyle"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_marginHorizontal="10dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_neutral"
+                    android:button="@null"
+                    android:paddingHorizontal="10dp" />
 
             <RadioButton
-                android:id="@+id/wellButton"
-                style="?android:borderlessButtonStyle"
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                android:layout_marginHorizontal="10dp"
-                android:layout_weight="1"
-                android:background="@drawable/ic_happy"
-                android:button="@null" />
+                    android:id="@+id/wellButton"
+                    style="?android:borderlessButtonStyle"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_marginHorizontal="10dp"
+                    android:layout_weight="1"
+                    android:background="@drawable/ic_happy"
+                    android:button="@null" />
 
         </RadioGroup>
 
         <Button
-            android:id="@+id/submit_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:enabled="false"
-            android:paddingVertical="10dp"
-            android:text="@string/submit_button" />
+                android:id="@+id/submit_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:paddingVertical="10dp"
+                android:text="@string/submit_button" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,12 +14,15 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
-    <style name="AppTheme.CustomTheme">
+    <style name="AppTheme.CustomDialogTheme">
         <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowIsFloating">true</item>
         <item name="android:windowCloseOnTouchOutside">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:layout_gravity">center</item>
     </style>
 
     <style name="RadioButtonWithTextOnTop">


### PR DESCRIPTION
Fixed an issue where the stying of the feedback activity would slightly block things that weren't behind it. The code that was hardcoding the size of the activity was replaced with wrap_content and gravity center.

Before: 
![before](https://user-images.githubusercontent.com/23544999/79311082-e5ac7680-7eca-11ea-9e0b-3eb5dc44604d.gif)

After: 
![after](https://user-images.githubusercontent.com/23544999/79310889-a2ea9e80-7eca-11ea-92df-6c74e9e86749.gif)
