### PR TITLE
Fix bug with multiple passed sessions

### DIFF
--- a/app/src/main/java/com/ui/fitit/adapters/EventAdapter.java
+++ b/app/src/main/java/com/ui/fitit/adapters/EventAdapter.java
@@ -1,6 +1,5 @@
 package com.ui.fitit.adapters;
 
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,28 +9,33 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import com.google.firebase.firestore.WriteBatch;
 import com.ui.fitit.R;
 import com.ui.fitit.data.model.Attendance;
 import com.ui.fitit.data.model.ScheduleItem;
+import com.ui.fitit.ui.main.MainActivity;
 import com.ui.fitit.ui.main.ScheduleFragment;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class EventAdapter extends ArrayAdapter<ScheduleItem> {
 
     private ScheduleFragment scheduleFragment;
-    private Context context;
+    private MainActivity activity;
 
 
-    public EventAdapter(@NonNull Context context, ScheduleFragment scheduleFragment, int textViewResourceId) {
-        super(context, textViewResourceId, scheduleFragment.scheduleItems);
+    public EventAdapter(@NonNull MainActivity activity, ScheduleFragment scheduleFragment, int textViewResourceId) {
+        super(activity, textViewResourceId, scheduleFragment.scheduleItems);
         this.scheduleFragment = scheduleFragment;
-        this.context = context;
+        this.activity = activity;
+
     }
 
     @Override
     @NonNull
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         if (convertView == null) {
-            convertView = LayoutInflater.from(context).inflate(R.layout.schedule_item, parent, false);
+            convertView = LayoutInflater.from(activity).inflate(R.layout.schedule_item, parent, false);
         }
         ScheduleItem item = getItem(position);
         if (item != null) {
@@ -69,7 +73,9 @@ public class EventAdapter extends ArrayAdapter<ScheduleItem> {
         itemCompleteCheckbox.setChecked(false);
         itemCompleteCheckbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (isChecked) {
-                scheduleFragment.onSessionAttended(item.getEvent(), item.getSession(), Attendance.COMPLETED);
+                WriteBatch batch = activity.db.batch();
+                AtomicInteger updates = new AtomicInteger(1);
+                scheduleFragment.onSessionAttended(item.getEvent(), item.getSession(), Attendance.COMPLETED, batch, updates);
             }
         });
     }

--- a/app/src/main/java/com/ui/fitit/ui/main/MainActivity.java
+++ b/app/src/main/java/com/ui/fitit/ui/main/MainActivity.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 public class MainActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener {
 
     private static final String TAG = "MainActivity";
-    final FirebaseFirestore db = FirebaseFirestore.getInstance();
+    public final FirebaseFirestore db = FirebaseFirestore.getInstance();
     final CollectionReference userCollection = db.collection(Constants.USERS_COLLECTION);
     CollectionReference feedbackCollection;
 

--- a/app/src/main/java/com/ui/fitit/ui/main/ScheduleFragment.java
+++ b/app/src/main/java/com/ui/fitit/ui/main/ScheduleFragment.java
@@ -151,6 +151,9 @@ public class ScheduleFragment extends Fragment {
                         onSessionAttended(event, session, Attendance.COMPLETED, batch, pendingUpdates);
                     }).setNegativeButton("Missed", (dialog, which) -> {
                         onSessionAttended(event, session, Attendance.MISSED, batch, pendingUpdates);
+                    }).setOnCancelListener(dialog -> {
+                        pendingUpdates.decrementAndGet();
+                        batchCommitAttempt(batch, pendingUpdates);
                     }).setTitle("An upcoming session now passed!")
                             .setMessage(String.format("\"%s\" was an upcoming event that now passed. Did you complete or miss it?", event.getName())).show();
                 }
@@ -196,6 +199,10 @@ public class ScheduleFragment extends Fragment {
             updateGroupPoints(newAttendance, event);
             pendingUpdates.decrementAndGet();
         }
+        batchCommitAttempt(batch, pendingUpdates);
+    }
+
+    private void batchCommitAttempt(WriteBatch batch, AtomicInteger pendingUpdates) {
         if (pendingUpdates.get() == 0) {
             batch.commit();
         }


### PR DESCRIPTION
If multiple sessions were missed, a bug would happen where session would be duplicated by mistake. This bug was caused by the fact that the verifySchedule() mathod is called every time there is an update.

Lets say that you have two upcoming sessions that pass. Once you complete/miss one event through the alert, the db is updated and the verifySchedule() is called again, now seeing that 1 upcoming session is passed, giving three alerts in total